### PR TITLE
skip default expand config option properly

### DIFF
--- a/lua/twilight/config.lua
+++ b/lua/twilight/config.lua
@@ -30,6 +30,7 @@ M.expand = {}
 
 function M.setup(options)
   M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
+	M.expand = {}
   for _, value in pairs(M.options.expand) do
     M.expand[value] = true
   end


### PR DESCRIPTION
It seems twilight **default expand** options are added on top of user defined **expand** options, thus we cant clear eg. "if_statement" or "table" elements from expand tab.  This PR fixes the issue.